### PR TITLE
Update UI in radiolist/grid view to address UI issue

### DIFF
--- a/iconfont.sketchplugin/Contents/Sketch/add_icon_radiolist.cocoascript
+++ b/iconfont.sketchplugin/Contents/Sketch/add_icon_radiolist.cocoascript
@@ -22,7 +22,7 @@ var onRun = function(context,icon_path,title,fontname) {
   var icon_list = Library.iconValues(icons,fontname)
   var icon_count = icon_list[0].length;
   // row count and height calculate
-  var row_count = Math.ceil(icon_count / 15);
+  var row_count = Math.ceil(icon_count / 11);
   var list_height = Math.ceil(row_count * 50);
 
   // create a wrapper window
@@ -41,7 +41,7 @@ var onRun = function(context,icon_path,title,fontname) {
   [prototype setBezelStyle:NSThickSquareBezelStyle]
 
   var iconMatrix = [[NSMatrix alloc] initWithFrame:NSMakeRect(0, 45, 545, list_height)
-    mode:NSListModeMatrix prototype:prototype numberOfRows:row_count numberOfColumns:15];
+    mode:NSListModeMatrix prototype:prototype numberOfRows:row_count numberOfColumns:11];
   var cellArray = [iconMatrix cells];
   [iconMatrix setFont:[NSFont fontWithName:@""+fontname size:20.0]]
   [iconMatrix setCellSize:NSMakeSize(47, 47)];


### PR DESCRIPTION
Fixed UI bug in grid/radio-list view that prevented you from seeing the last four columns of icons. Simply reduced the number of columns from 11 to 15.