### PR TITLE
Add the version number to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Latest Version](https://img.shields.io/github/release/keremciu/sketch-iconfont.svg?style=flat-square)](https://github.com/keremciu/sketch-iconfont/releases)
 [![Join the chat at https://gitter.im/keremciu/sketch-iconfont](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/keremciu/sketch-iconfont?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-### New Features and Fixes - 17 August 2016
+### New Features and Fixes - 17 August 2016 (Version 4.4.0)
 
 Hey guys, I've fixed the problem with 3.91 version of Sketch. 
 


### PR DESCRIPTION
This way, people know which version exactly fixed it and helps keep a mental map around versions to use vs. what version they're on, and so forth. (I recommend including version numbers for any date-including, version-based update sections, e.g. the 29 April one too.)