### PR TITLE
Fixed "Convert Icons [Outlines] shortcut

### DIFF
--- a/iconfont.sketchplugin/Contents/Sketch/manifest.json
+++ b/iconfont.sketchplugin/Contents/Sketch/manifest.json
@@ -11,7 +11,7 @@
     {
       "script" : "convert.js",
       "handler" : "onRun",
-      "shortcut" : "cmd ctrl u",
+      "shortcut" : "cmd ctrl o",
       "name" : "Convert Icons [Outlines]",
       "identifier" : "convert"
     },


### PR DESCRIPTION
Was duplicate shortcut from "Details of Selected Icon". Changed key from "U" to "O"