### PR TITLE
When replacing a textlayer, use same fontsize

### DIFF
--- a/iconfont.sketchplugin/Contents/Sketch/const/library.js
+++ b/iconfont.sketchplugin/Contents/Sketch/const/library.js
@@ -104,10 +104,13 @@ var Library = {
           selected.setStringValue(icon)
           // set icon name
           selected.setName(name)
-
-          // 8. set selected font
+		
+          //use same font size
+          var _fontsize = selected.fontSize()
+	  
+	  // 8. set selected font
           if (sketchVersion > 370) {
-            selected.setFont([NSFont fontWithName:@""+fontname size:fontsize])
+            selected.setFont([NSFont fontWithName:@""+fontname size:_fontsize])
           } else {
             [selected setFontPostscriptName:@""+fontname];
           }


### PR DESCRIPTION
Currently, when replacing an existing text layer, the plugin use the fontsize stated in config.json instead of keeping the same fontsize of text layer.

I'm no developer so please let me know if there's a better way to do this!